### PR TITLE
fix: http_server_native to close ReadableStream on abort signal

### DIFF
--- a/http_server_native.ts
+++ b/http_server_native.ts
@@ -79,6 +79,10 @@ export class Server<AS extends State = Record<string, any>>
     const { signal } = this.#options;
     const { onListen, ...options } = this.#options;
     const { promise, resolve } = createPromiseWithResolvers<Listener>();
+    if (signal?.aborted) {
+      // if user somehow aborted before `listen` is invoked, we throw
+      return Promise.reject(new Error("aborted prematurely before 'listen' event"));
+    }
     this.#stream = new ReadableStream<NativeRequest>({
       start: (controller) => {
         this.#httpServer = serve?.({

--- a/http_server_native.ts
+++ b/http_server_native.ts
@@ -96,6 +96,9 @@ export class Server<AS extends State = Record<string, any>>
           signal,
           ...options,
         });
+        // closinng stream, so that the Application listen promise can resolve itself
+        // https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamDefaultController/close
+        signal?.addEventListener("abort", () => controller.close(), { once: true });
       },
     });
 


### PR DESCRIPTION
See PR towards the upstream repo: https://github.com/oakserver/oak/pull/685

# How to test

## Step 1

clone this branch, check that all tests pass

```
deno test -A
```

## Step 2

comment out this line: https://github.com/Thesephi/oak/blob/19f37f7492aea26c03aaa0559afdf05e04d71915/http_server_native.ts#L105

then rerun the test, 1 should fail:
```
Application.listen() - no options - aborted after onListen ...
ok | 0 passed | 0 failed (2s)

error: Promise resolution is still pending but the event loop has already resolved.
```